### PR TITLE
add Roadmap link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Use this repository to report bugs or suggest improvements. GitHub is the recomm
 ## Before opening an issue
 
 - Search existing issues to avoid duplicates.
+- Check the [Roadmap](https://app.notion.com/p/meotimdihia/c76b651424df4d46837e4710301340bd?v=c152efba2ae84bb6b0c2a615539d83e2) to see if the suggestion has already been reported or is already planned.
 - Keep each issue focused on one topic.
 - For bugs, include the page URL, reproduction steps, expected result, and screenshots when useful.
 - For suggestions, explain the problem and what a good result would look like.
-
+  
 ## Discord
 
 You can also discuss feedback with the community:


### PR DESCRIPTION
Added a link to the Roadmap under “Before opening an issue” so users can check whether a suggestion is already planned before opening a new issue.